### PR TITLE
Fixed install script, simplified overall configuration. 🎆

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 venv/
 flask.cfg
 rpi_lock/
+rpi-lock.cfg

--- a/README.md
+++ b/README.md
@@ -8,29 +8,13 @@ In addition to using our RFID cards we can interact with the lock via a web inte
 
 ## Setup
 
-Complete Install
+1. Install the scripts
 
-```bash
-git clone https://github.com/chdsbd/rpi-lock &&
-bash rpi-lock/install.sh
-```
+   `git clone https://github.com/chdsbd/rpi-lock && bash rpi-lock/install.sh`
 
-Lite Install (w/o Web Interface)
+2. Change defaults in `rpi-lock.cfg`
 
-```bash
-git clone https://github.com/chdsbd/rpi-lock &&
-bash rpi-lock/install.sh -lite
-```
-
-*Note:* The environment variable `RPI_LOCK_CONFIG_PATH` must be set to override the default config values
-
-Crontab commands
-
-```bash
-sudo RPI_LOCK_CONFIG_PATH=/home/pi/rpi-lock/rpi-lock.cfg python /home/pi/rpi-lock/lock_interface.py
-sudo RPI_LOCK_CONFIG_PATH=/home/pi/rpi-lock/rpi-lock.cfg python /home/pi/rpi-lock/read_process.py
-sudo RPI_LOCK_CONFIG_PATH=/home/pi/rpi-lock/rpi-lock.cfg python /home/pi/rpi-lock/unlock_door.py
-```
+3. Reboot & Profit 💰
 
 ## Web Interface Utilizes
 

--- a/example-rpi-lock.cfg
+++ b/example-rpi-lock.cfg
@@ -7,7 +7,6 @@ PORT = 5001
 
 [PATH]
 RFID_STATUS_FILE = /tmp/rfid_running
-DATABASE = /home/pi/rpi-lock/doorlock.db
 
 [RFID]
 DATA1 = 7

--- a/install.sh
+++ b/install.sh
@@ -1,36 +1,9 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
-install="full"
-if [ "$1" == "-lite" ]; then
-    install="lite"
-fi
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-location="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-if [[ $install == "full" ]]; then
-    cmdlist=(
-    "lock_interface.py"
-    "read_process.py"
-    "unlock_door.py"
-    )
-else
-    cmdlist=(
-    "read_process.py"
-    "unlock_door.py"
-    )
-fi
-
-echo "setting up database"
-$location/sql_setup.py
-
-echo "starting lock"
-for cmd in ${cmdlist[*]}
-do
-    sudo $location/$cmd &
-done 
-
-echo "adding programs to cron"
-for cmd in ${cmdlist[*]}
-do
-    job="@reboot $location/$cmd"
-    cat <(fgrep -i -v "$cmd" <(sudo crontab -l)) <(echo "$job") | sudo crontab -
-done
+cd rpi-lock && \
+sudo pip install -r requirements.txt && \
+python sql_setup.py && \
+cp -n example-rpi-lock.cfg rpi-lock.cfg &&\
+(sudo crontab -l ; echo "@reboot bash $DIR/start-lock.sh") | sudo crontab -

--- a/lock_interface.py
+++ b/lock_interface.py
@@ -27,25 +27,27 @@ PASSWORD = 'default'
 SECRET_KEY = 'development key'
 DEBUG = True
 PORT = 5000
-DATABASE = 'doorlock.db'
+DATABASE = os.path.join(os.path.realpath(os.path.dirname(__file__)), "doorlock.db")
 RFID_STATUS_FILE = '/tmp/rfid_running'
 
 # use default settings located in this file
 app.config.from_object(__name__)
 
-# overwrite default settings with file set by the env variable if set
-if os.environ.get('RPI_LOCK_CONFIG_PATH') != (None and ''):
-    config = configparser.ConfigParser()
-    config.read(os.environ['RPI_LOCK_CONFIG_PATH'])
+config_file_paths = [os.path.expanduser('~/rpi-lock.cfg'),
+                     os.path.join(os.path.realpath(os.path.dirname(__file__)), "rpi-lock.cfg")]
+config = configparser.ConfigParser()
+config.read(config_file_paths)
+try:
     app.config.update(
     USERNAME = config.get("WEB", "USERNAME"),
     PASSWORD = config.get("WEB", "PASSWORD"),
     SECRET_KEY = config.get("WEB", "SECRET_KEY"),
     DEBUG = bool(config.get("WEB", "DEBUG")),
     PORT = int(config.get("WEB", "PORT")),
-    RFID_STATUS_FILE = config.get("PATH", "RFID_STATUS_FILE"),
-    DATABASE = config.get("PATH", "DATABASE"),
-)
+    RFID_STATUS_FILE = config.get("PATH", "RFID_STATUS_FILE"))
+except configparser.Error as e:
+    print("ConfigParser Error: ", e)
+
 
 def connect_db():
     return sqlite3.connect(str(app.config['DATABASE']))

--- a/read_process.py
+++ b/read_process.py
@@ -16,19 +16,21 @@ except ImportError:
 # Default values
 data0 = 11
 data1 = 7
-database = "doorlock.db"
+database = os.path.join(os.path.realpath(os.path.dirname(__file__)), "doorlock.db")
 base_timeout = 10
 rfid_status_file = "/tmp/rfid_running"
 
-# overwrite default settings with file set by the env variable if set
-if os.environ.get('RPI_LOCK_CONFIG_PATH') != (None and ''):
-    config = configparser.ConfigParser()
-    config.read(os.environ['RPI_LOCK_CONFIG_PATH'])
+config_file_paths = [os.path.expanduser('~/rpi-lock.cfg'),
+                     os.path.join(os.path.realpath(os.path.dirname(__file__)), "rpi-lock.cfg")]
+config = configparser.ConfigParser()
+config.read(config_file_paths)
+try:
     data0 = int(config.get("RFID", "DATA0"))
     data1 = int(config.get("RFID", "DATA1"))
     base_timeout = int(config.get("RFID", "BASE_TIMEOUT"))
-    database = config.get("PATH", "DATABASE").strip("'")
     rfid_status_file = config.get("PATH", "RFID_STATUS_FILE").strip("'")
+except configparser.Error as e:
+    print("ConfigParser Error: ", e)
 
 timeout = base_timeout
 bits = ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Jinja2==2.8
 MarkupSafe==0.23
 Werkzeug==0.11.4
 wheel==0.24.0
+RPi.GPIO==0.5.11

--- a/sql_setup.py
+++ b/sql_setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-from contextlib import closing
 import os
 import sqlite3
+from contextlib import closing
 
-DATABASE = 'doorlock.db'
+DATABASE = os.path.join(os.path.realpath(os.path.dirname(__file__)), "doorlock.db")
 
 # SQL must be setup as user so table is editable by user
 
@@ -20,7 +20,4 @@ def init_db():
         db.commit()
 
 if __name__ == '__main__':
-    try:
-        os.environ['SUDO_GID']
-    except KeyError:
-        init_db()
+    init_db()

--- a/start-lock.sh
+++ b/start-lock.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+python2 $DIR/lock_interface.py &
+python2 $DIR/read_process.py &
+python2 $DIR/unlock_door.py &

--- a/unlock_door.py
+++ b/unlock_door.py
@@ -15,14 +15,17 @@ frequency = 50 # Hz
 servo_pin = 27
 duty_cycle_open, duty_cycle_closed = 6, 3  # in %
 
-# overwrite default settings with file set by the env variable if set
-if os.environ.get('RPI_LOCK_CONFIG_PATH') != (None and ''):
-    config = configparser.ConfigParser()
-    config.read(os.environ['RPI_LOCK_CONFIG_PATH'])
+config_file_paths = [os.path.expanduser('~/rpi-lock.cfg'),
+                     os.path.join(os.path.realpath(os.path.dirname(__file__)), "rpi-lock.cfg")]
+config = configparser.ConfigParser()
+config.read(config_file_paths)
+try:
     duty_cycle_open = int(config.get("SERVO", "OPEN"))
     duty_cycle_closed = int(config.get("SERVO", "CLOSED"))
     servo_pin = int(config.get("SERVO", "PIN"))
     frequency = int(config.get("SERVO", "FREQUENCY"))
+except configparser.Error as e:
+    print("ConfigParser Error: ", e)
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(servo_pin, GPIO.OUT)


### PR DESCRIPTION
I replaced the install script with something that works.

Environmental variables are no longer necessary for configuration. The `rpi-lock.cfg` file and the `doorlock.db` database should be placed in the `rpi-lock/` folder with all the other files.

Everything can now be started by typing `bash start-lock.sh`.

Also, when using the install file, crontab is setup so `start-lock.sh` will run on boot.

fixed issue #11 
